### PR TITLE
Refactor 'size' argument of join()

### DIFF
--- a/src/lamport-clock.js
+++ b/src/lamport-clock.js
@@ -7,13 +7,12 @@ class LamportClock {
   }
 
   tick () {
-    this.time++
-    return this.time
+    return new LamportClock(this.id, ++this.time)
   }
 
   merge (clock) {
     this.time = Math.max(this.time, clock.time)
-    return this
+    return new LamportClock(this.id, this.time)
   }
 
   clone () {

--- a/src/log-utils.js
+++ b/src/log-utils.js
@@ -106,13 +106,14 @@ class LogUtils {
     if (!LogUtils.isLog(log)) throw NotALogError()
 
     // Update the clock
-    log.clock.tick()
+    const clock = log.clock.tick()
 
-    // Add the entry to the log
+    // Add the entry to the log,
+    // as a named function to make it optimizable for VMs
     const appendToLog = (entry) => log.append(entry)
 
     // Create the entry and add it to the log
-    return Entry.create(ipfs, log.id, null, data, log.heads, log.clock)
+    return Entry.create(ipfs, log.id, null, data, log.heads, clock)
       .then(appendToLog)
   }
 
@@ -132,13 +133,10 @@ class LogUtils {
    *
    * @returns {Log}
    */
-  static join (a, b, size, id) {
+  static join (a, b, size = -1, id) {
     if (!isDefined(a) || !isDefined(b)) throw LogNotDefinedError()
     if (!LogUtils.isLog(a)) throw NotALogError()
     if (!LogUtils.isLog(b)) throw NotALogError()
-
-    // If size is not specified, join all entries by default
-    size = size && size > -1 ? size : (a.length + b.length)
 
     // If id is not specified, use greater id of the two logs
     id = id ? id : [a, b].sort((a, b) => a.id > b.id)[0].id

--- a/test/log.spec.js
+++ b/test/log.spec.js
@@ -905,6 +905,67 @@ apis.forEach((IpfsDaemon) => {
         assert.equal(log4.length, 10)
         assert.deepEqual(log4.values.map((e) => e.payload), expectedData)
       }))
+
+      describe('takes length as an argument', async(() => {
+        beforeEach(async(() => {
+          log1 = await(Log.append(ipfs, log1, "helloA1"))
+          log1 = await(Log.append(ipfs, log1, "helloA2"))
+          log2 = await(Log.append(ipfs, log2, "helloB1"))
+          log2 = await(Log.append(ipfs, log2, "helloB2"))
+        }))
+
+        it('joins only specified amount of entries - one entry', async(() => {
+          log1 = Log.join(log1, log2, 1)
+
+          const expectedData = [ 
+            'helloB2',
+          ]
+          const lastEntry = last(log1.values)
+
+          assert.equal(log1.length, 1)
+          assert.deepEqual(log1.values.map((e) => e.payload), expectedData)
+          assert.equal(lastEntry.next.length, 1)
+        }))
+
+        it('joins only specified amount of entries - two entries', async(() => {
+          log1 = Log.join(log1, log2, 2)
+
+          const expectedData = [ 
+            'helloA2', 'helloB2',
+          ]
+          const lastEntry = last(log1.values)
+
+          assert.equal(log1.length, 2)
+          assert.deepEqual(log1.values.map((e) => e.payload), expectedData)
+          assert.equal(lastEntry.next.length, 1)
+        }))
+
+        it('joins only specified amount of entries - three entries', async(() => {
+          log1 = Log.join(log1, log2, 3)
+
+          const expectedData = [ 
+            'helloB1', 'helloA2', 'helloB2',
+          ]
+          const lastEntry = last(log1.values)
+
+          assert.equal(log1.length, 3)
+          assert.deepEqual(log1.values.map((e) => e.payload), expectedData)
+          assert.equal(lastEntry.next.length, 1)
+        }))
+
+        it('joins only specified amount of entries - (all) four entries', async(() => {
+          log1 = Log.join(log1, log2, 4)
+
+          const expectedData = [ 
+            'helloA1', 'helloB1', 'helloA2', 'helloB2',
+          ]
+          const lastEntry = last(log1.values)
+
+          assert.equal(log1.length, 4)
+          assert.deepEqual(log1.values.map((e) => e.payload), expectedData)
+          assert.equal(lastEntry.next.length, 1)
+        }))
+      }))
     })
 
     describe('joinAll', () => {


### PR DESCRIPTION
Make sure join() returns the log at specified length
LamportClock will always return a new instance